### PR TITLE
Гризли ивент

### DIFF
--- a/Resources/Prototypes/Andromeda/Entities/Markers/Spawners/mobs.yml
+++ b/Resources/Prototypes/Andromeda/Entities/Markers/Spawners/mobs.yml
@@ -10,3 +10,17 @@
   - type: ConditionalSpawner
     prototypes:
       - MobRadioGuard
+
+- type: entity
+  name: спавнер Гризли
+  id: SpawnMobGrizly
+  parent: MarkerBase
+  components:
+  - type: Sprite
+    layers:
+      - state: green
+        sprite: Andromeda/NIKforest/grizzly.rsi
+      - state: alive
+  - type: ConditionalSpawner
+    prototypes:
+      - MobGrizzly

--- a/Resources/Prototypes/Andromeda/GameRules/events.yml
+++ b/Resources/Prototypes/Andromeda/GameRules/events.yml
@@ -43,3 +43,17 @@
     maxOccurences: 1
     duration: 1
   - type: PirateRadioSpawnRule
+
+- type: entity
+  parent: BaseGameRule
+  id: GrizzlySpawn
+  noSpawn: true
+  components:
+  - type: StationEvent
+    weight: 5
+    duration: 1
+    earliestStart: 45
+    reoccurrenceDelay: 60
+    minimumPlayers: 20
+  - type: RandomSpawnRule
+    prototype: SpawnMobGrizly

--- a/Resources/Prototypes/Andromeda/NIKforest's Prototypes/Grizzly.yml
+++ b/Resources/Prototypes/Andromeda/NIKforest's Prototypes/Grizzly.yml
@@ -35,7 +35,7 @@
   - type: CombatMode
   - type: SlowOnDamage
     speedModifierThresholds:
-      800: 0.7
+      600: 0.7
       1000: 0.5
   - type: MobMover
   - type: FireVisuals
@@ -73,7 +73,7 @@
   - type: AntiRottingContainer #A-13 Dragon fix full
   - type: MovementSpeedModifier
     baseWalkSpeed: 2
-    baseSprintSpeed: 4
+    baseSprintSpeed: 3.5
   - type: Sprite
     sprite: Andromeda/NIKforest/grizzly.rsi
     noRot: true
@@ -194,3 +194,11 @@
     - CannotSuicide
     - DoorBumpOpener
     - NoPaint
+  - type: Destructible
+    thresholds:
+    - trigger:
+        !type:DamageTypeTrigger
+        damageType: Blunt
+        damage: 1500
+      behaviors:
+      - !type:GibBehavior { }

--- a/Resources/Prototypes/Andromeda/NIKforest's Prototypes/Grizzly.yml
+++ b/Resources/Prototypes/Andromeda/NIKforest's Prototypes/Grizzly.yml
@@ -127,6 +127,8 @@
     spawned:
     - id: FoodMeatBear
       amount: 10
+  - type: Stamina
+    critThreshold: 300
   - type: InteractionPopup
     successChance: 0.25
     interactSuccessString: petting-success-bear


### PR DESCRIPTION
:cl:
- add: Спавн гризли.
- add: Ивент призывающий Гризли в рандомное место на станции. Имеет шанс спавна как дракон.
- tweak: Понижена скорость бега на 3.5 вместо 4 (должно было в прошлый раз быть 3.5, но из-за моей ошибки стало 4).
- tweak: Теперь что бы гибнуть Гризли нужно не 400 урона, а 1500.