### PR TITLE
Dev/c4

### DIFF
--- a/Content.Server/Sticky/Systems/StickySystem.cs
+++ b/Content.Server/Sticky/Systems/StickySystem.cs
@@ -10,6 +10,7 @@ using Content.Shared.Sticky;
 using Content.Shared.Sticky.Components;
 using Content.Shared.Verbs;
 using Robust.Shared.Containers;
+using Robust.Shared.Random; //A-13 Detonation of C4 during detaching
 using Robust.Shared.Utility;
 
 namespace Content.Server.Sticky.Systems;
@@ -22,6 +23,7 @@ public sealed class StickySystem : EntitySystem
     [Dependency] private readonly SharedHandsSystem _handsSystem = default!;
     [Dependency] private readonly SharedInteractionSystem _interactionSystem = default!;
     [Dependency] private readonly SharedAppearanceSystem _appearance = default!;
+    [Dependency] private readonly IRobustRandom _random = default!; //A-13 Detonation of C4 during detaching
 
     private const string StickerSlotId = "stickers_container";
 
@@ -139,8 +141,12 @@ public sealed class StickySystem : EntitySystem
         //A-13 Detonation of C4 during detaching start
         if (TryComp<C4DetonationByUnstickComponent>(uid, out var c4Comp))
         {
-            if (c4Comp.Detonation && TryComp<ActiveTimerTriggerComponent>(uid, out var activateComp))
+            if (c4Comp.Detonation
+                && TryComp<ActiveTimerTriggerComponent>(uid, out var activateComp)
+                && _random.NextFloat(0.0f, 1.0f) > 0.5f)
+            {
                 activateComp.TimeRemaining = 0;
+            }
         }
         //A-13 Detonation of C4 during detaching end
 

--- a/Content.Shared/Andromeda/Voomra/C4/C4DetonationByUnstickSystem.cs
+++ b/Content.Shared/Andromeda/Voomra/C4/C4DetonationByUnstickSystem.cs
@@ -1,3 +1,4 @@
+using Content.Shared.Explosion.Components;
 using Content.Shared.Verbs;
 
 namespace Content.Shared.Andromeda.Voomra.C4;
@@ -29,6 +30,9 @@ public sealed class C4DetonationByUnstickSystem : EntitySystem
 
     private void OnGetAltVerbs(EntityUid uid, C4DetonationByUnstickComponent component, GetVerbsEvent<AlternativeVerb> args)
     {
+        if (HasComp<ActiveTimerTriggerComponent>(uid))
+            return;
+
         args.Verbs.Add(new AlternativeVerb
         {
             Text = Loc.GetString("verb-c4-detonation-by-unstick", ("status", component.Detonation

--- a/Content.Shared/Andromeda/Voomra/C4/C4DetonationByUnstickSystem.cs
+++ b/Content.Shared/Andromeda/Voomra/C4/C4DetonationByUnstickSystem.cs
@@ -1,3 +1,4 @@
+using Content.Shared.Examine;
 using Content.Shared.Explosion.Components;
 using Content.Shared.Verbs;
 
@@ -16,6 +17,7 @@ public sealed class C4DetonationByUnstickSystem : EntitySystem
         SubscribeLocalEvent<C4DetonationByUnstickComponent, ComponentInit>(OnComponentInit);
         SubscribeLocalEvent<C4DetonationByUnstickComponent, ComponentRemove>(OnComponentRemove);
         SubscribeLocalEvent<C4DetonationByUnstickComponent, GetVerbsEvent<AlternativeVerb>>(OnGetAltVerbs);
+        SubscribeLocalEvent<C4DetonationByUnstickComponent, ExaminedEvent>(OnExamined);
     }
 
     private void OnComponentInit(EntityUid uid, C4DetonationByUnstickComponent component, ComponentInit args)
@@ -45,5 +47,11 @@ public sealed class C4DetonationByUnstickSystem : EntitySystem
     private void DoAltVerbs(C4DetonationByUnstickComponent component)
     {
         component.Detonation = !component.Detonation;
+    }
+
+    private void OnExamined(EntityUid uid, C4DetonationByUnstickComponent component, ExaminedEvent args)
+    {
+        if (component.Detonation)
+            args.PushMarkup(Loc.GetString("examine-c4-detonation-by-unstick"));
     }
 }

--- a/Resources/Locale/ru-RU/Andromeda/c4-detonation-by-unstick.ftl
+++ b/Resources/Locale/ru-RU/Andromeda/c4-detonation-by-unstick.ftl
@@ -1,3 +1,5 @@
 verb-c4-detonation-by-unstick = Детонация при попытке снятия: {$status}
 verb-c4-detonation-by-unstick-status-off = ВЫКЛ
 verb-c4-detonation-by-unstick-status-on = ВКЛ
+
+examine-c4-detonation-by-unstick = [color=red]Детонирует при попытке открепить[/color]


### PR DESCRIPTION

## Описание PR

Исправлена ошибка, из-за которой любой мог отключить детонацию при откреплении C4.
- https://app.unityspace.ru/spaces/10148/34118/tasks/287148

**Проверки**

Пункт меню:

- [ ] Заспавнить C4
- [ ] Через ПКМ по C4 убедиться, что пункт меню **"Детонация при попытке снятия"** ПРИСУТСТВУЕТ
- [ ] Установить C4 на любую поверхность
- [ ] Через ПКМ по C4 убедиться, что пункт меню **"Детонация при попытке снятия"** ОТСУТСТВУЕТ

Информация о статусе детонации:

- [ ] Заспавнить C4
- [ ] Установить детонацию при снятии
- [ ] Установить C4 на любую поверхность
- [ ] Через ЛКП+Shift (просмотр информации о предмете) убедиться, что есть красная надпись "Детонирует при попытке открепить"

50% шанс детонации:

1. Заспавнить C4
2. Установить детонацию при снятии
3. Установить C4 на любую поверхность
4. Попытаться открепить
5. Зафиксировать сработала ли детонация
6. Повторять пункты 1-5. Должно выходить ~50% шанс детонации

**Изменения для игроков**

:cl:
- fix: После активации, детонацию по откреплению нельзя будет отменить
- tweak: Отображается информация о статусе "детонации при откреплении"
- tweak: Детонация при откреплении происходит с 50% шансом
