### PR TITLE
C4 popup

### DIFF
--- a/Content.Shared/Andromeda/Voomra/C4/C4DetonationByUnstickSystem.cs
+++ b/Content.Shared/Andromeda/Voomra/C4/C4DetonationByUnstickSystem.cs
@@ -1,5 +1,6 @@
 using Content.Shared.Examine;
 using Content.Shared.Explosion.Components;
+using Content.Shared.Popups;
 using Content.Shared.Verbs;
 
 namespace Content.Shared.Andromeda.Voomra.C4;
@@ -10,6 +11,8 @@ namespace Content.Shared.Andromeda.Voomra.C4;
 /// /// <seealso cref="T:Content.Shared.Andromeda.Voomra.C4.C4DetonationByUnstickComponent"/>
 public sealed class C4DetonationByUnstickSystem : EntitySystem
 {
+    [Dependency] private readonly SharedPopupSystem _popupSystem = default!;
+
     public override void Initialize()
     {
         base.Initialize();
@@ -40,13 +43,19 @@ public sealed class C4DetonationByUnstickSystem : EntitySystem
             Text = Loc.GetString("verb-c4-detonation-by-unstick", ("status", component.Detonation
                 ? Loc.GetString("verb-c4-detonation-by-unstick-status-on")
                 : Loc.GetString("verb-c4-detonation-by-unstick-status-off"))),
-            Act = () => DoAltVerbs(component)
+            Act = () => DoAltVerbs(component, uid, args.User)
         });
     }
 
-    private void DoAltVerbs(C4DetonationByUnstickComponent component)
+    private void DoAltVerbs(C4DetonationByUnstickComponent component, EntityUid c4, EntityUid user)
     {
         component.Detonation = !component.Detonation;
+        //есть странный баг: сообщение отображается задвоенно, словно popup вызывается дважды
+        _popupSystem.PopupEntity(
+            component.Detonation
+                ? Loc.GetString("popup-c4-detonation-by-unstick-on")
+                : Loc.GetString("popup-c4-detonation-by-unstick-off"),
+            c4, user);
     }
 
     private void OnExamined(EntityUid uid, C4DetonationByUnstickComponent component, ExaminedEvent args)

--- a/Resources/Locale/ru-RU/Andromeda/c4-detonation-by-unstick.ftl
+++ b/Resources/Locale/ru-RU/Andromeda/c4-detonation-by-unstick.ftl
@@ -3,3 +3,6 @@ verb-c4-detonation-by-unstick-status-off = ВЫКЛ
 verb-c4-detonation-by-unstick-status-on = ВКЛ
 
 examine-c4-detonation-by-unstick = [color=red]Детонирует при попытке открепить[/color]
+
+popup-c4-detonation-by-unstick-off = НЕ детонирует при попытке открепить
+popup-c4-detonation-by-unstick-on = Детонирует при попытке открепить


### PR DESCRIPTION
## Описание PR

Добавлен "попап" при переключении режимов детонации C4 при откреплении

### Проверки

- [ ] Заспавнить C4
- [ ] Клацнуть ПКМ по ней
- [ ] Клацнуть по меню "Детонация при попытке снятия"
- [ ] Над персонажем появится сообщение (попап)

*Есть странный баг: сообщение отображается задвоенно, словно popup вызывается дважды.*

### Изменения для игроков

:cl:
- tweak: Popup сообщение об изменении детонации при попытке снятия C4
